### PR TITLE
refactor: FinanceManager에 Repository 패턴 적용

### DIFF
--- a/src/app/incomeExpend/IncomeExpend.java
+++ b/src/app/incomeExpend/IncomeExpend.java
@@ -24,7 +24,6 @@ public class IncomeExpend {
 	 * 생성자
 	 * @param money 거래 금액
 	 * @param desc 설명
-	 * @param spendType 수입/지출 구분
 	 * @param eventType 구체적인 이벤트 구분
 	 */
 	public IncomeExpend(String id, Long money, String desc, IncomeExpendType IEType, EventType eventType) {
@@ -41,11 +40,26 @@ public class IncomeExpend {
 	 */
 	@Override
 	public String toString() {
-		// TODO Auto-generated method stub
 		String convertIEType = IEConverter.IETypeStringConverter(IEType);
 		String convertEventType = IEConverter.eventTypeStringConverter(eventType);
 		return String.format(MenuUtil.DEFAULT_PREFIX + "[id: %s , 금액 : %d , 수입지출타 : %s , 수입지출모델 : %s , 설명 : %s]\n", id,
 				money, convertIEType, convertEventType, desc);
+	}
+
+	/**
+	 * ID getter 메서드
+	 * @return ID
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * ID setter 메서드
+	 * @param id 설정할 ID
+	 */
+	public void setId(String id) {
+		this.id = id;
 	}
 
 }

--- a/src/app/repository/interfaces/IncomeExpendRepository.java
+++ b/src/app/repository/interfaces/IncomeExpendRepository.java
@@ -1,0 +1,59 @@
+package app.repository.interfaces;
+
+import app.incomeExpend.IncomeExpend;
+
+import java.util.List;
+
+/**
+ * IncomeExpend 엔티티를 위한 특화된 Repository 인터페이스입니다.
+ * 기본 CRUD 연산 외에 수입/지출 도메인 특화 기능을 제공합니다.
+ * 
+ * <p>주요 기능:</p>
+ * <ul>
+ *   <li>수입/지출 내역 기록 및 관리</li>
+ *   <li>수입/지출별 조회</li>
+ *   <li>총액 계산</li>
+ * </ul>
+ * 
+ * @author ManazooTeam
+ * @version 1.0
+ * @since 2025-09-03
+ */
+public interface IncomeExpendRepository extends Repository<IncomeExpend, String> {
+    
+    /**
+     * 새로운 수입/지출 내역을 생성합니다.
+     * 
+     * @param incomeExpend 생성할 수입/지출 객체
+     * @return 생성된 내역 객체
+     */
+    IncomeExpend createIncomeExpend(IncomeExpend incomeExpend);
+    
+    /**
+     * 모든 수입 내역을 조회합니다.
+     * 
+     * @return 수입 내역 목록
+     */
+    List<IncomeExpend> getIncomeList();
+    
+    /**
+     * 모든 지출 내역을 조회합니다.
+     * 
+     * @return 지출 내역 목록
+     */
+    List<IncomeExpend> getExpendList();
+    
+    /**
+     * 총 수입 금액을 계산합니다.
+     * 
+     * @return 총 수입 금액
+     */
+    Long getTotalIncomes();
+    
+    /**
+     * 총 지출 금액을 계산합니다.
+     * 
+     * @return 총 지출 금액
+     */
+    Long getTotalExpends();
+}

--- a/src/app/repository/memory/MemoryIncomeExpendRepository.java
+++ b/src/app/repository/memory/MemoryIncomeExpendRepository.java
@@ -1,0 +1,202 @@
+package app.repository.memory;
+
+import app.incomeExpend.IncomeExpend;
+import app.incomeExpend.IncomeExpendType;
+import app.repository.interfaces.IncomeExpendRepository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * IncomeExpend 엔티티를 위한 메모리 기반 Repository 구현체입니다.
+ * 
+ * <p>메모리 내 HashMap을 사용하여 수입/지출 데이터를 관리합니다.</p>
+ * 
+ * @author ManazooTeam
+ * @version 1.0
+ * @since 2025-09-03
+ */
+public class MemoryIncomeExpendRepository implements IncomeExpendRepository {
+    
+    /** 수입/지출 내역을 저장하는 메모리 저장소 */
+    private final Map<String, IncomeExpend> storage = new HashMap<>();
+    
+    /**
+     * IncomeExpend를 저장소에 저장합니다.
+     * 
+     * @param incomeExpend 저장할 IncomeExpend 객체
+     * @return 저장된 IncomeExpend 객체
+     */
+    @Override
+    public IncomeExpend save(IncomeExpend incomeExpend) {
+        if (incomeExpend == null) {
+            throw new IllegalArgumentException("IncomeExpend는 null일 수 없습니다.");
+        }
+        
+        String id = incomeExpend.getId();
+        if (id == null || id.trim().isEmpty()) {
+            throw new IllegalArgumentException("IncomeExpend ID는 null이거나 빈 문자열일 수 없습니다.");
+        }
+        
+        storage.put(id, incomeExpend);
+        return incomeExpend;
+    }
+    
+    /**
+     * ID로 IncomeExpend를 조회합니다.
+     * 
+     * @param id 조회할 IncomeExpend의 ID
+     * @return 조회된 IncomeExpend 객체, 없으면 empty Optional
+     */
+    @Override
+    public Optional<IncomeExpend> findById(String id) {
+        if (id == null || id.trim().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(storage.get(id));
+    }
+    
+    /**
+     * 모든 IncomeExpend를 조회합니다.
+     * 
+     * @return 모든 IncomeExpend 목록
+     */
+    @Override
+    public List<IncomeExpend> findAll() {
+        return new ArrayList<>(storage.values());
+    }
+    
+    /**
+     * IncomeExpend를 업데이트합니다.
+     * 
+     * @param incomeExpend 업데이트할 IncomeExpend 객체
+     * @return 업데이트된 IncomeExpend 객체
+     */
+    @Override
+    public IncomeExpend update(IncomeExpend incomeExpend) {
+        if (incomeExpend == null) {
+            throw new IllegalArgumentException("IncomeExpend는 null일 수 없습니다.");
+        }
+        
+        String id = incomeExpend.getId();
+        if (id == null || id.trim().isEmpty()) {
+            throw new IllegalArgumentException("IncomeExpend ID는 null이거나 빈 문자열일 수 없습니다.");
+        }
+        
+        if (!storage.containsKey(id)) {
+            throw new IllegalArgumentException("업데이트하려는 IncomeExpend가 존재하지 않습니다: " + id);
+        }
+        
+        storage.put(id, incomeExpend);
+        return incomeExpend;
+    }
+    
+    /**
+     * ID로 IncomeExpend를 삭제합니다.
+     * 
+     * @param id 삭제할 IncomeExpend의 ID
+     * @return 삭제 성공 여부
+     */
+    @Override
+    public boolean deleteById(String id) {
+        if (id == null || id.trim().isEmpty()) {
+            return false;
+        }
+        return storage.remove(id) != null;
+    }
+    
+    /**
+     * IncomeExpend가 존재하는지 확인합니다.
+     * 
+     * @param id 확인할 IncomeExpend의 ID
+     * @return 존재 여부
+     */
+    @Override
+    public boolean existsById(String id) {
+        if (id == null || id.trim().isEmpty()) {
+            return false;
+        }
+        return storage.containsKey(id);
+    }
+    
+    /**
+     * 모든 IncomeExpend를 삭제합니다.
+     */
+    @Override
+    public void deleteAll() {
+        storage.clear();
+    }
+    
+    /**
+     * 전체 IncomeExpend 개수를 반환합니다.
+     * 
+     * @return 전체 개수
+     */
+    @Override
+    public long count() {
+        return storage.size();
+    }
+    
+    /**
+     * 새로운 수입/지출 내역을 생성합니다.
+     * 
+     * @param incomeExpend 생성할 수입/지출 객체
+     * @return 생성된 내역 객체
+     */
+    @Override
+    public IncomeExpend createIncomeExpend(IncomeExpend incomeExpend) {
+        return save(incomeExpend);
+    }
+    
+    /**
+     * 모든 수입 내역을 조회합니다.
+     * 
+     * @return 수입 내역 목록
+     */
+    @Override
+    public List<IncomeExpend> getIncomeList() {
+        return storage.values().stream()
+                .filter(ie -> ie.IEType == IncomeExpendType.INCOME)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 모든 지출 내역을 조회합니다.
+     * 
+     * @return 지출 내역 목록
+     */
+    @Override
+    public List<IncomeExpend> getExpendList() {
+        return storage.values().stream()
+                .filter(ie -> ie.IEType == IncomeExpendType.EXPEND)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 총 수입 금액을 계산합니다.
+     * 
+     * @return 총 수입 금액
+     */
+    @Override
+    public Long getTotalIncomes() {
+        return getIncomeList().stream()
+                .mapToLong(ie -> ie.money)
+                .sum();
+    }
+    
+    /**
+     * 총 지출 금액을 계산합니다.
+     * 
+     * @return 총 지출 금액
+     */
+    @Override
+    public Long getTotalExpends() {
+        return getExpendList().stream()
+                .mapToLong(ie -> ie.money)
+                .sum();
+    }
+}


### PR DESCRIPTION
## 📋 PR 개요

### 🎯 작업 유형(Required)
- [ ] 🆕 새로운 기능 추가
- [ ] 🐛 버그 수정
- [x] 🔧 리팩토링
- [ ] 📚 문서 업데이트
- [ ] 🧪 테스트 추가/수정
- [ ] 🎨 UI/UX 개선

### 📝 변경 사항 요약(Required)
refactor: FinanceManager에 Repository 패턴 적용

- 기존 List<IncomeExpend> 직접 사용을 IncomeExpendRepository 인터페이스로 교체
- MemoryIncomeExpendRepository 구현체로 메모리 기반 수입/지출 데이터 관리
- IncomeExpend 클래스에 getId()/setId() 메서드 추가로 Repository 호환성 확보
- 모든 수입/지출 CRUD 작업을 Repository 메서드로 통일
- 데이터 접근 로직과 비즈니스 로직 분리로 유지보수성 향상
- Animal/Visitor 패키지와 일관된 Repository 패턴 적용

기능 변경 없이 아키텍처 개선으로 전체 프로젝트의 데이터 접근 패턴 통일

### 🔗 관련 이슈(Required)

- Closes #57   
- Related to #39 
